### PR TITLE
Revert "Use THREE.LineSegments instead of THREE.Line for edges"

### DIFF
--- a/src/mainview.tsx
+++ b/src/mainview.tsx
@@ -414,7 +414,6 @@ export class MainView extends React.Component<IProps, IStates> {
       }
       const vertices: Array<any> = [];
       const normals: Array<any> = [];
-      const edges: Array<any> = [];
       const triangles: Array<any> = [];
 
       let vInd = 0;
@@ -434,10 +433,6 @@ export class MainView extends React.Component<IProps, IStates> {
         }
 
         vInd += face.vertexCoord.length / 3;
-      });
-
-      edgeList.forEach(edge => {
-        edges.push(...edge.vertexCoord);
       });
 
       // Compile the connected vertices and faces into a model
@@ -477,15 +472,17 @@ export class MainView extends React.Component<IProps, IStates> {
         linewidth: 5,
         color: 'black'
       });
+      edgeList.forEach(edge => {
+        const edgeVertices = new THREE.Float32BufferAttribute(
+          edge.vertexCoord,
+          3
+        );
+        const edgeGeometry = new THREE.BufferGeometry();
+        edgeGeometry.setAttribute('position', edgeVertices);
+        const mesh = new THREE.Line(edgeGeometry, edgeMaterial);
 
-      const edgesGeometry = new THREE.BufferGeometry();
-      edgesGeometry.setAttribute(
-        'position',
-        new THREE.Float32BufferAttribute(edges, 3)
-      );
-      const mesh = new THREE.LineSegments(edgesGeometry, edgeMaterial);
-
-      model.add(mesh);
+        model.add(mesh);
+      });
 
       this._meshGroup!.add(model);
 


### PR DESCRIPTION
Reverts QuantStack/jupytercad#9

This PR should be reverted. It was a misunderstanding of how `edges` provided by OpenCascade works.
The PR would have worked if an edge was a list of two points, but an edge here is a list of undetermined number of points, so `THREE.Line` makes more sense.

Fix #17