### PR TITLE
Handle de-select when selecting a non-visible object

### DIFF
--- a/src/mainview.tsx
+++ b/src/mainview.tsx
@@ -564,7 +564,6 @@ export class MainView extends React.Component<IProps, IStates> {
       }
     } else {
       // Sync local state updated by other components
-
       const localState = clients.get(clientId);
       if (localState) {
         if (
@@ -572,14 +571,16 @@ export class MainView extends React.Component<IProps, IStates> {
           localState.selected?.emitter !== this.state.id
         ) {
           if (this._selectedMesh?.name !== localState.selected.value) {
-            this._meshGroup?.children.forEach(obj => {
-              if (obj.name === localState.selected.value) {
-                this._selectedMesh = obj as THREE.Mesh<
+            const selectedMesh = this._meshGroup?.children.filter(obj => obj.name === localState.selected.value);
+
+            if (selectedMesh?.length) {
+              this._selectedMesh = selectedMesh[0] as THREE.Mesh<
                   THREE.BufferGeometry,
                   THREE.MeshBasicMaterial
                 >;
-              }
-            });
+            } else {
+              this._selectedMesh = null;
+            }
           }
         } else {
           this._selectedMesh = null;

--- a/src/mainview.tsx
+++ b/src/mainview.tsx
@@ -571,13 +571,15 @@ export class MainView extends React.Component<IProps, IStates> {
           localState.selected?.emitter !== this.state.id
         ) {
           if (this._selectedMesh?.name !== localState.selected.value) {
-            const selectedMesh = this._meshGroup?.children.filter(obj => obj.name === localState.selected.value);
+            const selectedMesh = this._meshGroup?.children.filter(
+              obj => obj.name === localState.selected.value
+            );
 
             if (selectedMesh?.length) {
               this._selectedMesh = selectedMesh[0] as THREE.Mesh<
-                  THREE.BufferGeometry,
-                  THREE.MeshBasicMaterial
-                >;
+                THREE.BufferGeometry,
+                THREE.MeshBasicMaterial
+              >;
             } else {
               this._selectedMesh = null;
             }


### PR DESCRIPTION
Selecting a non-visible object in the tree view would not deselect the previously selected object in the 3D view, this PR fixes this use-case.