### PR TITLE
Display and sync pointers between clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,13 @@
     "@jupyterlab/ui-components": "^4.0.0-alpha.19",
     "@naisutech/react-tree": "^3.0.1",
     "@rjsf/core": "^4.2.0",
+    "@types/d3-color": "^3.1.0",
     "@types/three": "^0.134.0",
+    "d3-color": "^3.1.0",
     "opencascade.js": "2.0.0-beta.371bbb0",
     "styled-components": "^5.3.6",
     "three": "^0.135.0",
+    "three-mesh-bvh": "^0.5.17",
     "uuid": "^8.3.2"
   },
   "resolutions": {

--- a/src/model.ts
+++ b/src/model.ts
@@ -14,7 +14,8 @@ import {
   IJupyterCadDoc,
   IJupyterCadDocChange,
   IJupyterCadModel,
-  Position
+  PointerPosition,
+  Camera
 } from './types';
 import { yMapToJcadObject } from './tools';
 
@@ -142,14 +143,21 @@ export class JupyterCadModel implements IJupyterCadModel {
     return all;
   }
 
-  syncCamera(pos: Position | undefined, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField('mouse', {
-      value: pos,
+  syncPointer(position?: PointerPosition, emitter?: string): void {
+    this.sharedModel.awareness.setLocalStateField('pointer', {
+      value: position ? [position.x, position.y, position.z] : undefined,
       emitter: emitter
     });
   }
 
-  syncSelectedObject(name: string | null, emitter?: string): void {
+  syncCamera(camera?: Camera, emitter?: string): void {
+    this.sharedModel.awareness.setLocalStateField('camera', {
+      value: camera,
+      emitter: emitter
+    });
+  }
+
+  syncSelectedObject(name?: string, emitter?: string): void {
     this.sharedModel.awareness.setLocalStateField('selected', {
       value: name,
       emitter: emitter

--- a/src/panelview/objecttree.tsx
+++ b/src/panelview/objecttree.tsx
@@ -251,7 +251,7 @@ class ObjectTreeReact extends React.Component<IProps, IStates> {
                 );
               }
             } else {
-              this.props.cpModel.jcadModel?.syncSelectedObject(null);
+              this.props.cpModel.jcadModel?.syncSelectedObject(undefined);
             }
           }}
           onToggleOpenNodes={nodes =>
@@ -315,7 +315,7 @@ class ObjectTreeReact extends React.Component<IProps, IStates> {
                             objectId
                           );
                           this.props.cpModel.jcadModel?.syncSelectedObject(
-                            null
+                            undefined
                           );
                         }}
                         icon={closeIcon}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { MapChange, YDocument } from '@jupyterlab/shared-models';
 import { ReactWidget } from '@jupyterlab/ui-components';
+import { ICurrentUser } from '@jupyterlab/collaboration';
 import { ISignal, Signal } from '@lumino/signaling';
 import * as Y from 'yjs';
 
@@ -89,12 +90,22 @@ export interface IWorkerInitialized {
 
 export type IMainMessage = IDisplayShape | IWorkerInitialized;
 
-export type Position = {
-  offsetX: number;
-  offsetY: number;
+/**
+ * Position of the user pointer in the 3D environment
+ */
+export type PointerPosition = {
   x: number;
   y: number;
   z: number;
+};
+
+/**
+ * Position and orientation of the user Camera
+ */
+export type Camera = {
+  position: number[];
+  rotation: number[];
+  up: number[];
 };
 
 export interface IJcadObjectDocChange {
@@ -112,7 +123,9 @@ export interface IJupyterCadDocChange {
   }>;
   optionChange?: MapChange;
 }
+
 export type IJCadObjectDoc = Y.Map<any>;
+
 export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   objects: Y.Array<IJCadObjectDoc>;
   options: Y.Map<any>;
@@ -124,10 +137,12 @@ export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
 }
 
 export interface IJupyterCadClientState {
-  mouse: { value?: Position | null; emitter?: string | null };
-  selected: { value?: string | null; emitter?: string | null };
-  user: any;
+  pointer: { value?: PointerPosition; emitter?: string | null };
+  camera: { value?: Camera; emitter?: string | null };
+  selected: { value?: string; emitter?: string | null };
+  user: ICurrentUser;
 }
+
 export interface IJupyterCadModel extends DocumentRegistry.IModel {
   isDisposed: boolean;
   sharedModelChanged: ISignal<IJupyterCadModel, IJupyterCadDocChange>;
@@ -143,12 +158,14 @@ export interface IJupyterCadModel extends DocumentRegistry.IModel {
   getWorker(): Worker;
   getContent(): IJCadContent;
   getAllObject(): IJCadModel;
-  syncCamera(pos: Position | undefined, emitter?: string): void;
-  syncSelectedObject(name: string | null, emitter?: string): void;
+  syncPointer(position: PointerPosition | undefined, emitter?: string): void;
+  syncCamera(camera: Camera | undefined, emitter?: string): void;
+  syncSelectedObject(name: string | undefined, emitter?: string): void;
   getClientId(): number;
 }
 
 export type IJupyterCadWidget = IDocumentWidget<ReactWidget, IJupyterCadModel>;
+
 export interface IControlPanelModel {
   disconnect(f: any): void;
   documentChanged: ISignal<IJupyterCadTracker, IJupyterCadWidget | null>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,6 +1573,11 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/d3-color@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.0.tgz#6594da178ded6c7c3842f3cc0ac84b156f12f2d4"
+  integrity sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==
+
 "@types/dom4@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.2.tgz#6495303f049689ce936ed328a3e5ede9c51408ee"
@@ -2786,6 +2791,11 @@ csstype@~3.0.3:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
   integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
+
+d3-color@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -6491,6 +6501,11 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+three-mesh-bvh@^0.5.17:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.5.17.tgz#1f9bdcd7992e86dc3665664c1fe5cedd7be4bd9f"
+  integrity sha512-0iyqZe0Op6tH7nqVI4L2Ae1tACiYliJvx0cFvehrVzzfZRW8p4c9GYnqGPPN5+x7Q8L5WjJC8kgoA8Z+/+1oAQ==
 
 three@^0.135.0:
   version "0.135.0"


### PR DESCRIPTION
This PR:
- [x] Removes the color-picking logic and implements a BVH picking instead, this has the benefit of being allowed to **retrieve the projected pointer position when picking**
- [x] Displays all the user pointers, using the user color
- [x] Removes the "highlight on hover" feature, as it does not give any more visual information than the pointer now
- [x] Re-implements the camera syncing between users, syncing the entire camera position and orientation information (position, rotation, up, target). This will be useful later when implementing a "follow" feature

Demo: (the user on the right side is hovering the meshes with his mouse, and his pointer is visible to any contributor)

[Screencast from 11-09-2022 04:21:43 PM.webm](https://user-images.githubusercontent.com/21197331/200871010-b2686f6e-d6c9-4be3-b24a-46daa0fcce82.webm)
