### PR TITLE
Remove "getCoordinate" from the Annotation Model

### DIFF
--- a/src/annotation/model.ts
+++ b/src/annotation/model.ts
@@ -16,7 +16,6 @@ export interface IAnnotation {
 
 export class AnnotationModel {
   constructor(options: AnnotationModel.IOptions) {
-    this._getCoordinate = options.getCoordinate;
     this._sharedModel = options.sharedModel;
     const state = this._sharedModel.awareness.getLocalState();
     this._user = state?.user;
@@ -49,13 +48,6 @@ export class AnnotationModel {
     this._sharedModel.removeMetadata(key);
   }
 
-  getCoordinate(id: string): [number, number] | undefined {
-    const annotation = this.getAnnotation(id);
-    if (annotation?.position) {
-      return this._getCoordinate(annotation.position);
-    }
-  }
-
   addContent(id: string, value: string): void {
     const newContent: IAnnotationContent = {
       value,
@@ -73,7 +65,6 @@ export class AnnotationModel {
   }
 
   private _sharedModel: IJupyterCadDoc;
-  private _getCoordinate: (input: [number, number, number]) => [number, number];
   private _updateSignal = new Signal<this, null>(this);
   private _user?: User.IIdentity;
 }
@@ -81,6 +72,5 @@ export class AnnotationModel {
 namespace AnnotationModel {
   export interface IOptions {
     sharedModel: IJupyterCadDoc;
-    getCoordinate: (input: [number, number, number]) => [number, number];
   }
 }

--- a/src/mainview.tsx
+++ b/src/mainview.tsx
@@ -108,8 +108,7 @@ export class MainView extends React.Component<IProps, IStates> {
         this._messageChannel.port2
       );
       this._annotationModel = new AnnotationModel({
-        sharedModel: this._model.sharedModel,
-        getCoordinate: this._projectVector
+        sharedModel: this._model.sharedModel
       });
       this._model.themeChanged.connect(this._handleThemeChange);
       this._model.clientStateChanged.connect(this._onClientSharedStateChanged);
@@ -435,7 +434,13 @@ export class MainView extends React.Component<IProps, IStates> {
           options.updatePosition &&
           (el.style.opacity !== '0' || options.updateDisplay !== undefined)
         ) {
-          const newPos = this._annotationModel.getCoordinate(key) ?? [0, 0];
+          const annotation = this._annotationModel.getAnnotation(key);
+          let newPos: [number, number] | undefined;
+          if (annotation?.position) {
+            newPos = this._projectVector(annotation.position);
+          } else {
+            newPos = [0, 0];
+          }
           el.style.top = `${newPos[1]}px`;
           el.style.left = `${newPos[0]}px`;
         }


### PR DESCRIPTION
This will make it easier to reuse the annotation model from outside the main view