### PR TITLE
Types the API and hides Y data structures

### DIFF
--- a/src/annotation/model.ts
+++ b/src/annotation/model.ts
@@ -34,7 +34,7 @@ export class AnnotationModel {
   }
 
   getAnnotation(id: string): IAnnotation | undefined {
-    const rawData = this._sharedModel.metadata.get(id);
+    const rawData = this._sharedModel.getMetadata(id);
     if (rawData) {
       return JSON.parse(rawData) as IAnnotation;
     }

--- a/src/mainview.tsx
+++ b/src/mainview.tsx
@@ -657,13 +657,12 @@ export class MainView extends React.Component<IProps, IStates> {
     _: IJupyterCadDoc,
     changes: MapChange
   ) => {
-    const metaData = this._model.sharedModel.metadata;
     const newState = { ...this.state.annotations };
     changes.forEach((val, key) => {
       if (!key.startsWith('annotation')) {
         return;
       }
-      const data = metaData.get(key);
+      const data = this._model.sharedModel.getMetadata(key);
       let open = true;
       if (this.state.firstLoad) {
         open = false;

--- a/src/model.ts
+++ b/src/model.ts
@@ -256,27 +256,6 @@ export class JupyterCadDoc
     return this._metadataChanged;
   }
 
-  /**
-   * Undo an operation.
-   */
-  undo(): void {
-    this.undoManager.undo();
-  }
-
-  /**
-   * Redo an operation.
-   */
-  redo(): void {
-    this.undoManager.redo();
-  }
-
-  /**
-   * Clear the change stack.
-   */
-  clearUndoHistory(): void {
-    this.undoManager.clear();
-  }
-
   getObjectByName(name: string): IJCadObject | undefined {
     const obj = this._getObjectAsYMapByName(name);
     if (obj) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -299,7 +299,7 @@ export class JupyterCadDoc
   }
 
   getOption(key: string): JSONValue {
-    return this._options.get(key);
+    return JSONExt.deepCopy(this._options.get(key));
   }
 
   setOption(key: string, value: JSONValue): void {

--- a/src/model.ts
+++ b/src/model.ts
@@ -248,22 +248,12 @@ export class JupyterCadDoc
   get options(): JSONObject {
     return JSONExt.deepCopy(this._options.toJSON());
   }
-  get metadata(): Y.Map<string> {
-    return this._metadata;
+  get metadata(): JSONObject {
+    return JSONExt.deepCopy(this._metadata.toJSON());
   }
 
   get metadataChanged(): ISignal<IJupyterCadDoc, MapChange> {
     return this._metadataChanged;
-  }
-
-  setMetadata(key: string, value: string): void {
-    this._metadata.set(key, value);
-  }
-
-  removeMetadata(key: string): void {
-    if (this._metadata.has(key)) {
-      this._metadata.delete(key);
-    }
   }
 
   /**
@@ -340,6 +330,20 @@ export class JupyterCadDoc
   setOptions(options: JSONObject): void {
     for (const [key, value] of Object.entries(options)) {
       this._options.set(key, value);
+    }
+  }
+
+  getMetadata(key: string): string | undefined {
+    return this._metadata.get(key);
+  }
+
+  setMetadata(key: string, value: string): void {
+    this._metadata.set(key, value);
+  }
+
+  removeMetadata(key: string): void {
+    if (this._metadata.has(key)) {
+      this._metadata.delete(key);
     }
   }
 

--- a/src/panelview/objectproperties.tsx
+++ b/src/panelview/objectproperties.tsx
@@ -1,8 +1,11 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import { PanelWithToolbar } from '@jupyterlab/ui-components';
+
 import { Panel } from '@lumino/widgets';
-import { JSONExt } from '@lumino/coreutils';
+
+import { v4 as uuid } from 'uuid';
 import * as React from 'react';
+
 import {
   focusInputField,
   itemFromName,
@@ -19,7 +22,6 @@ import {
 import { IJCadModel } from '../_interface/jcad';
 import { ObjectPropertiesForm } from './formbuilder';
 import formSchema from '../_interface/forms.json';
-import { v4 as uuid } from 'uuid';
 
 export class ObjectProperties extends PanelWithToolbar {
   constructor(params: ObjectProperties.IOptions) {
@@ -99,18 +101,13 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
       return;
     }
 
-    const currentYMap =
-      this.props.cpModel.jcadModel?.sharedModel.getObjectByName(objectName);
-    if (currentYMap) {
-      const newParams = {
-        ...JSONExt.deepCopy(currentYMap.get('parameters')),
+    const model = this.props.cpModel.jcadModel?.sharedModel;
+    const obj = model?.getObjectByName(objectName);
+    if (model && obj) {
+      model.updateObjectByName(objectName, 'parameters', {
+        ...obj['parameters'],
         ...properties
-      };
-      this.props.cpModel.jcadModel?.sharedModel.updateObjectByName(
-        objectName,
-        'parameters',
-        newParams
-      );
+      });
     }
   }
 

--- a/src/toolbar/operatortoolbar.tsx
+++ b/src/toolbar/operatortoolbar.tsx
@@ -1,9 +1,11 @@
-import * as React from 'react';
-import { ToolbarModel } from './model';
 import { Button } from '@jupyterlab/ui-components';
+
+import * as React from 'react';
+
+import { ToolbarModel } from './model';
 import { IDict } from '../types';
 import { FormDialog } from './formdialog';
-import * as Y from 'yjs';
+import { IJCadObject } from '../_interface/jcad';
 interface IProps {
   toolbarModel: ToolbarModel;
 }
@@ -48,7 +50,7 @@ export class OperatorToolbarReact extends React.Component<IProps> {
         },
         syncData: (props: IDict) => {
           const { Name, ...parameters } = props;
-          const objectModel = {
+          const objectModel: IJCadObject = {
             shape: 'Part::Cut',
             parameters,
             visible: true,
@@ -56,13 +58,10 @@ export class OperatorToolbarReact extends React.Component<IProps> {
           };
           const model = this.props.toolbarModel.sharedModel;
           if (model) {
-            const base = model.getObjectByName(parameters['Base']);
-            const tool = model.getObjectByName(parameters['Tool']);
-            const object = new Y.Map<any>(Object.entries(objectModel));
             model.transact(() => {
-              base && base.set('visible', false);
-              tool && tool.set('visible', false);
-              model.addObject(object);
+              model.updateObjectByName(parameters['Base'], 'visible', false);
+              model.updateObjectByName(parameters['Tool'], 'visible', false);
+              model.addObject(objectModel);
             });
           }
         }
@@ -78,7 +77,7 @@ export class OperatorToolbarReact extends React.Component<IProps> {
         },
         syncData: (props: IDict) => {
           const { Name, ...parameters } = props;
-          const objectModel = {
+          const objectModel: IJCadObject = {
             shape: 'Part::MultiFuse',
             parameters,
             visible: true,
@@ -86,9 +85,8 @@ export class OperatorToolbarReact extends React.Component<IProps> {
           };
           const model = this.props.toolbarModel.sharedModel;
           if (model) {
-            const object = new Y.Map<any>(Object.entries(objectModel));
             model.transact(() => {
-              model.addObject(object);
+              model.addObject(objectModel);
             });
           }
         }
@@ -104,7 +102,7 @@ export class OperatorToolbarReact extends React.Component<IProps> {
         },
         syncData: (props: IDict) => {
           const { Name, ...parameters } = props;
-          const objectModel = {
+          const objectModel: IJCadObject = {
             shape: 'Part::MultiCommon',
             parameters,
             visible: true,
@@ -112,9 +110,8 @@ export class OperatorToolbarReact extends React.Component<IProps> {
           };
           const model = this.props.toolbarModel.sharedModel;
           if (model) {
-            const object = new Y.Map<any>(Object.entries(objectModel));
             model.transact(() => {
-              model.addObject(object);
+              model.addObject(objectModel);
             });
           }
         }

--- a/src/toolbar/parttoolbar.tsx
+++ b/src/toolbar/parttoolbar.tsx
@@ -2,7 +2,7 @@ import { Button } from '@jupyterlab/ui-components';
 import * as React from 'react';
 
 import { IDict } from '../types';
-import { IJCadObject } from '../_interface/jcad';
+import { IJCadObject, Parts } from '../_interface/jcad';
 import { FormDialog } from './formdialog';
 import { ToolbarModel } from './model';
 
@@ -107,7 +107,7 @@ export class PartToolbarReact extends React.Component<IProps> {
                 syncData: (props: IDict) => {
                   const { Name, ...parameters } = props;
                   const objectModel: IJCadObject = {
-                    shape: value.shape as any,
+                    shape: value.shape as Parts,
                     parameters,
                     visible: true,
                     name: Name

--- a/src/toolbar/parttoolbar.tsx
+++ b/src/toolbar/parttoolbar.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@jupyterlab/ui-components';
 import * as React from 'react';
-import * as Y from 'yjs';
 
 import { IDict } from '../types';
+import { IJCadObject } from '../_interface/jcad';
 import { FormDialog } from './formdialog';
 import { ToolbarModel } from './model';
 
@@ -106,16 +106,15 @@ export class PartToolbarReact extends React.Component<IProps> {
                 schema: value.schema,
                 syncData: (props: IDict) => {
                   const { Name, ...parameters } = props;
-                  const objectModel = {
-                    shape: value.shape,
+                  const objectModel: IJCadObject = {
+                    shape: value.shape as any,
                     parameters,
                     visible: true,
                     name: Name
                   };
                   const model = this.props.toolbarModel.sharedModel;
                   if (model) {
-                    const object = new Y.Map<any>(Object.entries(objectModel));
-                    model.addObject(object);
+                    model.addObject(objectModel);
                   }
                 },
                 cancelButton: () => {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,7 +1,4 @@
-import * as Y from 'yjs';
-
 import { LabIcon } from '@jupyterlab/ui-components';
-import { IJCadObject } from './_interface/jcad';
 
 const jvControlLight =
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><g class="jp-icon3" fill="#616161"><g><path d="M2,6c0.55,0,1-0.45,1-1V4c0-0.55,0.45-1,1-1h1c0.55,0,1-0.45,1-1S5.55,1,5,1H4C2.34,1,1,2.34,1,4v1C1,5.55,1.45,6,2,6z"/><path d="M5,21H4c-0.55,0-1-0.45-1-1v-1c0-0.55-0.45-1-1-1c-0.55,0-1,0.45-1,1v1c0,1.66,1.34,3,3,3h1c0.55,0,1-0.45,1-1 S5.55,21,5,21z"/><path d="M20,1h-1c-0.55,0-1,0.45-1,1s0.45,1,1,1h1c0.55,0,1,0.45,1,1v1c0,0.55,0.45,1,1,1c0.55,0,1-0.45,1-1V4 C23,2.34,21.66,1,20,1z"/><path d="M22,18c-0.55,0-1,0.45-1,1v1c0,0.55-0.45,1-1,1h-1c-0.55,0-1,0.45-1,1s0.45,1,1,1h1c1.66,0,3-1.34,3-3v-1 C23,18.45,22.55,18,22,18z"/><path d="M19,14.87V9.13c0-0.72-0.38-1.38-1-1.73l-5-2.88c-0.31-0.18-0.65-0.27-1-0.27s-0.69,0.09-1,0.27L6,7.39 C5.38,7.75,5,8.41,5,9.13v5.74c0,0.72,0.38,1.38,1,1.73l5,2.88c0.31,0.18,0.65,0.27,1,0.27s0.69-0.09,1-0.27l5-2.88 C18.62,16.25,19,15.59,19,14.87z M11,17.17l-4-2.3v-4.63l4,2.33V17.17z M12,10.84L8.04,8.53L12,6.25l3.96,2.28L12,10.84z M17,14.87l-4,2.3v-4.6l4-2.33V14.87z"/></g></g></svg>';
@@ -23,14 +20,6 @@ export const debounce = (
     }, timeout);
   };
 };
-
-export function yMapToJcadObject(ymap: Y.Map<any>): IJCadObject {
-  const values = {} as IJCadObject;
-  for (const [key, value] of ymap.entries()) {
-    values[key] = value;
-  }
-  return values;
-}
 
 export function itemFromName<T extends { name: string }>(
   name: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,17 @@
-import { IJCadObject } from './_interface/jcad.d';
-import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
-import { MapChange, YDocument, StateChange } from '@jupyter/ydoc';
+import { IChangedArgs } from '@jupyterlab/coreutils';
 import { ReactWidget } from '@jupyterlab/ui-components';
 import { User } from '@jupyterlab/services';
 
+import { MapChange, YDocument, StateChange } from '@jupyter/ydoc';
+
 import { ISignal, Signal } from '@lumino/signaling';
+import { JSONObject } from '@lumino/coreutils';
 
 import * as Y from 'yjs';
 
 import { IJupyterCadTracker } from './token';
-import { IJCadContent, IJCadModel } from './_interface/jcad';
+import { IJCadContent, IJCadObject, IJCadModel } from './_interface/jcad';
 
 export interface IDict<T = any> {
   [key: string]: T;
@@ -129,7 +130,7 @@ export interface IJupyterCadDocChange {
 
 export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   objects: Array<IJCadObject>;
-  options: Y.Map<any>;
+  options: JSONObject;
   metadata: Y.Map<string>;
 
   getObjectByName(name: string): IJCadObject | undefined;
@@ -137,8 +138,10 @@ export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   addObject(value: IJCadObject): void;
   addObjects(value: Array<IJCadObject>): void;
   updateObjectByName(name: string, key: string, value: any): void;
+
   getOption(key: string): any;
   setOption(key: string, value: any): void;
+  setOptions(options: JSONObject): void;
 
   setMetadata(key: string, value: string): void;
   removeMetadata(key: string): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,6 @@ import { MapChange, YDocument, StateChange } from '@jupyter/ydoc';
 import { ISignal, Signal } from '@lumino/signaling';
 import { JSONObject } from '@lumino/coreutils';
 
-import * as Y from 'yjs';
-
 import { IJupyterCadTracker } from './token';
 import { IJCadContent, IJCadObject, IJCadModel } from './_interface/jcad';
 
@@ -131,7 +129,7 @@ export interface IJupyterCadDocChange {
 export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   objects: Array<IJCadObject>;
   options: JSONObject;
-  metadata: Y.Map<string>;
+  metadata: JSONObject;
 
   getObjectByName(name: string): IJCadObject | undefined;
   removeObjectByName(name: string): void;
@@ -143,6 +141,7 @@ export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
   setOption(key: string, value: any): void;
   setOptions(options: JSONObject): void;
 
+  getMetadata(key: string): string | undefined;
   setMetadata(key: string, value: string): void;
   removeMetadata(key: string): void;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,9 @@ import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { MapChange, YDocument, StateChange } from '@jupyter/ydoc';
 import { ReactWidget } from '@jupyterlab/ui-components';
 import { User } from '@jupyterlab/services';
+
 import { ISignal, Signal } from '@lumino/signaling';
+
 import * as Y from 'yjs';
 
 import { IJupyterCadTracker } from './token';
@@ -125,16 +127,15 @@ export interface IJupyterCadDocChange {
   stateChange?: StateChange<any>[];
 }
 
-export type IJCadObjectDoc = Y.Map<any>;
-
 export interface IJupyterCadDoc extends YDocument<IJupyterCadDocChange> {
-  objects: Y.Array<IJCadObjectDoc>;
+  objects: Array<IJCadObject>;
   options: Y.Map<any>;
   metadata: Y.Map<string>;
 
-  getObjectByName(name: string): IJCadObjectDoc | undefined;
+  getObjectByName(name: string): IJCadObject | undefined;
   removeObjectByName(name: string): void;
-  addObject(value: IJCadObjectDoc): void;
+  addObject(value: IJCadObject): void;
+  addObjects(value: Array<IJCadObject>): void;
   updateObjectByName(name: string, key: string, value: any): void;
   getOption(key: string): any;
   setOption(key: string, value: any): void;


### PR DESCRIPTION
~There is a small type issue here:~
https://github.com/QuantStack/jupytercad/blob/7d5af28eea58cda1c2b51d3b218672eec3ca811d/src/toolbar/parttoolbar.tsx#L110

~In the type IJCadObject, `shape` is a `Parts | undefined` while in the schema `shape` is a `string`. See:~

https://github.com/QuantStack/jupytercad/blob/7d5af28eea58cda1c2b51d3b218672eec3ca811d/src/toolbar/parttoolbar.tsx#L21

Edit: Never mind, there is no issue at all.