### PR TITLE
Fix bot for updating galata references

### DIFF
--- a/.github/workflows/update_galata_references.yaml
+++ b/.github/workflows/update_galata_references.yaml
@@ -38,7 +38,7 @@ jobs:
           pr: ${{github.event.issue.number}}
           workflow: "build.yml"
           workflow_conclusion: ""
-          name: myextension-whl
+          name: extension-artifacts
 
       - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
@@ -54,7 +54,7 @@ jobs:
         shell: bash -l {0}
         run: |
           whereis python
-          python -m pip install --find-links=. jupytercad
+          python -m pip install jupytercad*.whl
           python -m pip install "jupyterlab>=4.0.0a32"
 
       - name: Install dependencies


### PR DESCRIPTION
The bot was failing in https://github.com/QuantStack/jupytercad/pull/105 (see https://github.com/QuantStack/jupytercad/actions/runs/3988108977/jobs/6838812889). I guess this should be the proper fix but we will only be able to test it once merged on main.