### PR TITLE
Add launcher buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
         "@jupyterlab/collaboration": "~4.0.0-alpha.17",
         "@jupyterlab/coreutils": "~6.0.0-alpha.17",
         "@jupyterlab/docregistry": "~4.0.0-alpha.17",
+        "@jupyterlab/filebrowser": "~4.0.0-alpha.17",
+        "@jupyterlab/launcher": "~4.0.0-alpha.17",
         "@jupyterlab/mainmenu": "~4.0.0-alpha.17",
         "@jupyterlab/observables": "~5.0.0-alpha.17",
         "@jupyterlab/services": "~7.0.0-alpha.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ name = "jupytercad"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
-dependencies = ["jupyterlab>=4.0.0a32", "jupyter_server>=2.0.6", "jupyter_ydoc==0.2.2"]
+dependencies = [
+    "jupyterlab>=4.0.0a32",
+    "jupyter_server>=2.0.6",
+    "jupyter_ydoc>=0.2.0,<0.3.0"
+]
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",

--- a/src/fcplugin/plugins.ts
+++ b/src/fcplugin/plugins.ts
@@ -22,7 +22,7 @@ import { IAnnotationModel, IJupyterCadWidget } from '../types';
 
 const FACTORY = 'Jupytercad Freecad Factory';
 
-const PALETTE_CATEGORY = 'JupyterCAD';
+// const PALETTE_CATEGORY = 'JupyterCAD';
 
 namespace CommandIDs {
   export const createNew = 'jupytercad:create-new-FCStd-file';
@@ -35,7 +35,7 @@ const activate = (
   annotationModel: IAnnotationModel,
   browserFactory: IFileBrowserFactory,
   launcher: ILauncher | null,
-  palette: ICommandPalette | null,
+  palette: ICommandPalette | null
 ): void => {
   // Creating the widget factory to register it so the document manager knows about
   // our new DocumentWidget
@@ -79,13 +79,14 @@ const activate = (
   });
 
   app.commands.addCommand(CommandIDs.createNew, {
-    label: args => args['isPalette'] ? 'New FCStd Editor' : 'FCStd Editor',
+    label: args => (args['isPalette'] ? 'New FCStd Editor' : 'FCStd Editor'),
     caption: 'Create a new FCStd Editor',
     icon: args => (args['isPalette'] ? undefined : fileIcon),
     execute: async args => {
       // Get the directory in which the FCStd file must be created;
       // otherwise take the current filebrowser directory
-      const cwd = (args['cwd'] || browserFactory.tracker.currentWidget?.model.path) as string;
+      const cwd = (args['cwd'] ||
+        browserFactory.tracker.currentWidget?.model.path) as string;
 
       // Create a new untitled Blockly file
       let model = await app.serviceManager.contents.newUntitled({
@@ -94,16 +95,13 @@ const activate = (
         ext: '.FCStd'
       });
 
-      console.debug("Model:", model);
-      model = await app.serviceManager.contents.save(
-        model.path,
-        {
-          ...model,
-          format: 'base64',
-          size: undefined,
-          content: btoa("")
-        }
-      );
+      console.debug('Model:', model);
+      model = await app.serviceManager.contents.save(model.path, {
+        ...model,
+        format: 'base64',
+        size: undefined,
+        content: btoa('')
+      });
 
       // Open the newly created file with the 'Editor'
       return app.commands.execute('docmanager:open', {
@@ -115,26 +113,31 @@ const activate = (
 
   // Add the command to the launcher
   if (launcher) {
-    launcher.add({
+    /* launcher.add({
       command: CommandIDs.createNew,
       category: 'Other',
       rank: 1
-    });
+    }); */
   }
 
   // Add the command to the palette
   if (palette) {
-    palette.addItem({
+    /* palette.addItem({
       command: CommandIDs.createNew,
       args: { isPalette: true },
       category: PALETTE_CATEGORY
-    });
+    }); */
   }
 };
 
 const fcplugin: JupyterFrontEndPlugin<void> = {
   id: 'jupytercad:fcplugin',
-  requires: [IJupyterCadDocTracker, IThemeManager, IAnnotation, IFileBrowserFactory],
+  requires: [
+    IJupyterCadDocTracker,
+    IThemeManager,
+    IAnnotation,
+    IFileBrowserFactory
+  ],
   optional: [ILauncher, ICommandPalette],
   autoStart: true,
   activate

--- a/src/fcplugin/plugins.ts
+++ b/src/fcplugin/plugins.ts
@@ -3,7 +3,17 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { IThemeManager, WidgetTracker } from '@jupyterlab/apputils';
+import {
+  ICommandPalette,
+  IThemeManager,
+  WidgetTracker
+} from '@jupyterlab/apputils';
+
+import { fileIcon } from '@jupyterlab/ui-components';
+
+import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+
+import { ILauncher } from '@jupyterlab/launcher';
 
 import { JupyterCadWidgetFactory } from '../factory';
 import { IAnnotation, IJupyterCadDocTracker } from './../token';
@@ -12,11 +22,20 @@ import { IAnnotationModel, IJupyterCadWidget } from '../types';
 
 const FACTORY = 'Jupytercad Freecad Factory';
 
+const PALETTE_CATEGORY = 'JupyterCAD';
+
+namespace CommandIDs {
+  export const createNew = 'jupytercad:create-new-FCStd-file';
+}
+
 const activate = (
   app: JupyterFrontEnd,
   tracker: WidgetTracker<IJupyterCadWidget>,
   themeManager: IThemeManager,
-  annotationModel: IAnnotationModel
+  annotationModel: IAnnotationModel,
+  browserFactory: IFileBrowserFactory,
+  launcher: ILauncher | null,
+  palette: ICommandPalette | null,
 ): void => {
   // Creating the widget factory to register it so the document manager knows about
   // our new DocumentWidget
@@ -58,11 +77,65 @@ const activate = (
     app.shell.activateById('jupytercad::leftControlPanel');
     app.shell.activateById('jupytercad::rightControlPanel');
   });
+
+  app.commands.addCommand(CommandIDs.createNew, {
+    label: args => args['isPalette'] ? 'New FCStd Editor' : 'FCStd Editor',
+    caption: 'Create a new FCStd Editor',
+    icon: args => (args['isPalette'] ? undefined : fileIcon),
+    execute: async args => {
+      // Get the directory in which the FCStd file must be created;
+      // otherwise take the current filebrowser directory
+      const cwd = (args['cwd'] || browserFactory.tracker.currentWidget?.model.path) as string;
+
+      // Create a new untitled Blockly file
+      let model = await app.serviceManager.contents.newUntitled({
+        path: cwd,
+        type: 'file',
+        ext: '.FCStd'
+      });
+
+      console.debug("Model:", model);
+      model = await app.serviceManager.contents.save(
+        model.path,
+        {
+          ...model,
+          format: 'base64',
+          size: undefined,
+          content: btoa("")
+        }
+      );
+
+      // Open the newly created file with the 'Editor'
+      return app.commands.execute('docmanager:open', {
+        path: model.path,
+        factory: FACTORY
+      });
+    }
+  });
+
+  // Add the command to the launcher
+  if (launcher) {
+    launcher.add({
+      command: CommandIDs.createNew,
+      category: 'Other',
+      rank: 1
+    });
+  }
+
+  // Add the command to the palette
+  if (palette) {
+    palette.addItem({
+      command: CommandIDs.createNew,
+      args: { isPalette: true },
+      category: PALETTE_CATEGORY
+    });
+  }
 };
 
 const fcplugin: JupyterFrontEndPlugin<void> = {
   id: 'jupytercad:fcplugin',
-  requires: [IJupyterCadDocTracker, IThemeManager, IAnnotation],
+  requires: [IJupyterCadDocTracker, IThemeManager, IAnnotation, IFileBrowserFactory],
+  optional: [ILauncher, ICommandPalette],
   autoStart: true,
   activate
 };

--- a/src/jcadplugin/plugins.ts
+++ b/src/jcadplugin/plugins.ts
@@ -34,7 +34,7 @@ const activate = (
   annotationModel: IAnnotationModel,
   browserFactory: IFileBrowserFactory,
   launcher: ILauncher | null,
-  palette: ICommandPalette | null,
+  palette: ICommandPalette | null
 ): void => {
   const widgetFactory = new JupyterCadWidgetFactory({
     name: FACTORY,
@@ -74,13 +74,14 @@ const activate = (
   });
 
   app.commands.addCommand(CommandIDs.createNew, {
-    label: args => args['isPalette'] ? 'New JCAD Editor' : 'JCAD Editor',
+    label: args => (args['isPalette'] ? 'New JCAD Editor' : 'JCAD Editor'),
     caption: 'Create a new JCAD Editor',
     icon: args => (args['isPalette'] ? undefined : fileIcon),
     execute: async args => {
       // Get the directory in which the JCAD file must be created;
       // otherwise take the current filebrowser directory
-      const cwd = (args['cwd'] || browserFactory.tracker.currentWidget?.model.path) as string;
+      const cwd = (args['cwd'] ||
+        browserFactory.tracker.currentWidget?.model.path) as string;
 
       // Create a new untitled Blockly file
       let model = await app.serviceManager.contents.newUntitled({
@@ -89,16 +90,13 @@ const activate = (
         ext: '.jcad'
       });
 
-      console.debug("Model:", model);
-      model = await app.serviceManager.contents.save(
-        model.path,
-        {
-          ...model,
-          format: 'text',
-          size: undefined,
-          content: "{\n\t\"objects\": [],\n\t\"options\": {},\n\t\"metadata\": {}\n}"
-        }
-      );
+      console.debug('Model:', model);
+      model = await app.serviceManager.contents.save(model.path, {
+        ...model,
+        format: 'text',
+        size: undefined,
+        content: '{\n\t"objects": [],\n\t"options": {},\n\t"metadata": {}\n}'
+      });
 
       // Open the newly created file with the 'Editor'
       return app.commands.execute('docmanager:open', {
@@ -129,7 +127,12 @@ const activate = (
 
 const jcadPlugin: JupyterFrontEndPlugin<void> = {
   id: 'jupytercad:jcadplugin',
-  requires: [IJupyterCadDocTracker, IThemeManager, IAnnotation, IFileBrowserFactory],
+  requires: [
+    IJupyterCadDocTracker,
+    IThemeManager,
+    IAnnotation,
+    IFileBrowserFactory
+  ],
   optional: [ILauncher, ICommandPalette],
   autoStart: true,
   activate

--- a/src/jcadplugin/plugins.ts
+++ b/src/jcadplugin/plugins.ts
@@ -1,8 +1,19 @@
-import { IThemeManager, WidgetTracker } from '@jupyterlab/apputils';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+
+import {
+  ICommandPalette,
+  IThemeManager,
+  WidgetTracker
+} from '@jupyterlab/apputils';
+
+import { fileIcon } from '@jupyterlab/ui-components';
+
+import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+
+import { ILauncher } from '@jupyterlab/launcher';
 
 import { IAnnotationModel, IJupyterCadWidget } from './../types';
 import { IAnnotation, IJupyterCadDocTracker } from './../token';
@@ -10,12 +21,20 @@ import { JupyterCadWidgetFactory } from '../factory';
 import { JupyterCadJcadModelFactory } from './modelfactory';
 
 const FACTORY = 'Jupytercad Jcad Factory';
+const PALETTE_CATEGORY = 'JupyterCAD';
+
+namespace CommandIDs {
+  export const createNew = 'jupytercad:create-new-jcad-file';
+}
 
 const activate = (
   app: JupyterFrontEnd,
   tracker: WidgetTracker<IJupyterCadWidget>,
   themeManager: IThemeManager,
-  annotationModel: IAnnotationModel
+  annotationModel: IAnnotationModel,
+  browserFactory: IFileBrowserFactory,
+  launcher: ILauncher | null,
+  palette: ICommandPalette | null,
 ): void => {
   const widgetFactory = new JupyterCadWidgetFactory({
     name: FACTORY,
@@ -53,11 +72,65 @@ const activate = (
     app.shell.activateById('jupytercad::leftControlPanel');
     app.shell.activateById('jupytercad::rightControlPanel');
   });
+
+  app.commands.addCommand(CommandIDs.createNew, {
+    label: args => args['isPalette'] ? 'New JCAD Editor' : 'JCAD Editor',
+    caption: 'Create a new JCAD Editor',
+    icon: args => (args['isPalette'] ? undefined : fileIcon),
+    execute: async args => {
+      // Get the directory in which the JCAD file must be created;
+      // otherwise take the current filebrowser directory
+      const cwd = (args['cwd'] || browserFactory.tracker.currentWidget?.model.path) as string;
+
+      // Create a new untitled Blockly file
+      let model = await app.serviceManager.contents.newUntitled({
+        path: cwd,
+        type: 'file',
+        ext: '.jcad'
+      });
+
+      console.debug("Model:", model);
+      model = await app.serviceManager.contents.save(
+        model.path,
+        {
+          ...model,
+          format: 'text',
+          size: undefined,
+          content: "{\n\t\"objects\": [],\n\t\"options\": {},\n\t\"metadata\": {}\n}"
+        }
+      );
+
+      // Open the newly created file with the 'Editor'
+      return app.commands.execute('docmanager:open', {
+        path: model.path,
+        factory: FACTORY
+      });
+    }
+  });
+
+  // Add the command to the launcher
+  if (launcher) {
+    launcher.add({
+      command: CommandIDs.createNew,
+      category: 'Other',
+      rank: 1
+    });
+  }
+
+  // Add the command to the palette
+  if (palette) {
+    palette.addItem({
+      command: CommandIDs.createNew,
+      args: { isPalette: true },
+      category: PALETTE_CATEGORY
+    });
+  }
 };
 
 const jcadPlugin: JupyterFrontEndPlugin<void> = {
   id: 'jupytercad:jcadplugin',
-  requires: [IJupyterCadDocTracker, IThemeManager, IAnnotation],
+  requires: [IJupyterCadDocTracker, IThemeManager, IAnnotation, IFileBrowserFactory],
+  optional: [ILauncher, ICommandPalette],
   autoStart: true,
   activate
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,6 +800,28 @@
     path-browserify "^1.0.0"
     url-parse "~1.5.4"
 
+"@jupyterlab/docmanager@^4.0.0-alpha.17":
+  version "4.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docmanager/-/docmanager-4.0.0-alpha.17.tgz#dbd132a37b16d123fc71bdc4c828c7f00153bcc7"
+  integrity sha512-eyT2akjunbX59D/Fj7SPwzU5BEVNpiHZ1lwtloQMYU0cmLQfdV3IVE28Lt5Rlp8cZw3wGhO+nuUmd6LUZrznIQ==
+  dependencies:
+    "@jupyterlab/apputils" "^4.0.0-alpha.17"
+    "@jupyterlab/coreutils" "^6.0.0-alpha.17"
+    "@jupyterlab/docprovider" "^4.0.0-alpha.17"
+    "@jupyterlab/docregistry" "^4.0.0-alpha.17"
+    "@jupyterlab/services" "^7.0.0-alpha.17"
+    "@jupyterlab/statusbar" "^4.0.0-alpha.17"
+    "@jupyterlab/translation" "^4.0.0-alpha.17"
+    "@jupyterlab/ui-components" "^4.0.0-alpha.32"
+    "@lumino/algorithm" "^2.0.0-alpha.6"
+    "@lumino/coreutils" "^2.0.0-alpha.6"
+    "@lumino/disposable" "^2.0.0-alpha.6"
+    "@lumino/messaging" "^2.0.0-alpha.6"
+    "@lumino/properties" "^2.0.0-alpha.6"
+    "@lumino/signaling" "^2.0.0-alpha.6"
+    "@lumino/widgets" "^2.0.0-alpha.6"
+    react "^17.0.1"
+
 "@jupyterlab/docprovider@^4.0.0-alpha.17":
   version "4.0.0-alpha.17"
   resolved "https://registry.yarnpkg.com/@jupyterlab/docprovider/-/docprovider-4.0.0-alpha.17.tgz#13347c6ca5ec6bf343b41a70281eb5c5a742b19e"
@@ -852,6 +874,48 @@
     "@lumino/messaging" "^2.0.0-alpha.6"
     "@lumino/polling" "^2.0.0-alpha.6"
     "@lumino/signaling" "^2.0.0-alpha.6"
+    "@lumino/widgets" "^2.0.0-alpha.6"
+    react "^17.0.1"
+
+"@jupyterlab/filebrowser@~4.0.0-alpha.17":
+  version "4.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser/-/filebrowser-4.0.0-alpha.17.tgz#29522de1c9298e47843e95443bb6549d3030c54e"
+  integrity sha512-R+ylK5GPyOXqvRE1ebcGGt17G5Tx5g4rfNOSvhNjAjVWup6I+qpLdvDHi5w4Uw1yXzYfMhqrVJA9mEalITjsgQ==
+  dependencies:
+    "@jupyterlab/apputils" "^4.0.0-alpha.17"
+    "@jupyterlab/coreutils" "^6.0.0-alpha.17"
+    "@jupyterlab/docmanager" "^4.0.0-alpha.17"
+    "@jupyterlab/docregistry" "^4.0.0-alpha.17"
+    "@jupyterlab/services" "^7.0.0-alpha.17"
+    "@jupyterlab/statedb" "^4.0.0-alpha.17"
+    "@jupyterlab/statusbar" "^4.0.0-alpha.17"
+    "@jupyterlab/translation" "^4.0.0-alpha.17"
+    "@jupyterlab/ui-components" "^4.0.0-alpha.32"
+    "@lumino/algorithm" "^2.0.0-alpha.6"
+    "@lumino/coreutils" "^2.0.0-alpha.6"
+    "@lumino/disposable" "^2.0.0-alpha.6"
+    "@lumino/domutils" "^2.0.0-alpha.6"
+    "@lumino/dragdrop" "^2.0.0-alpha.6"
+    "@lumino/messaging" "^2.0.0-alpha.6"
+    "@lumino/polling" "^2.0.0-alpha.6"
+    "@lumino/signaling" "^2.0.0-alpha.6"
+    "@lumino/virtualdom" "^2.0.0-alpha.6"
+    "@lumino/widgets" "^2.0.0-alpha.6"
+    react "^17.0.1"
+
+"@jupyterlab/launcher@~4.0.0-alpha.17":
+  version "4.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/launcher/-/launcher-4.0.0-alpha.17.tgz#d5eab611e9a8c59e312eebe93b08d0b8afc8ea2e"
+  integrity sha512-M27tpm3YdZr2zQxGXPWN+l5Yc3P7DEdH1VUHolrfBZSknotq0/hEiwaPpVQWrL5yX1XfqKbNGcL3HWkAL10Y7Q==
+  dependencies:
+    "@jupyterlab/apputils" "^4.0.0-alpha.17"
+    "@jupyterlab/translation" "^4.0.0-alpha.17"
+    "@jupyterlab/ui-components" "^4.0.0-alpha.32"
+    "@lumino/algorithm" "^2.0.0-alpha.6"
+    "@lumino/commands" "^2.0.0-alpha.6"
+    "@lumino/coreutils" "^2.0.0-alpha.6"
+    "@lumino/disposable" "^2.0.0-alpha.6"
+    "@lumino/properties" "^2.0.0-alpha.6"
     "@lumino/widgets" "^2.0.0-alpha.6"
     react "^17.0.1"
 


### PR DESCRIPTION
Fixes #100 

The `FCStd` file doesn't work because as you can see [here](https://github.com/hbcarlos/jupytercad/blob/06fe6acad7629f90c9d7a795e3e6ff5786344748/src/jcadplugin/plugins.ts#L83-L101), we create a new file by calling the save method in the contents service and passing an empty document.

The Freecad format is a [standard zip file containing one or more files in a specific structure](https://wiki.freecadweb.org/File_Format_FCStd), there is no easy way of hardcoding this in the frontend.

Maybe this is a good opportunity to improve the RTC API.
