### PR TITLE
Remove `pip install -e .` step in the check release workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -25,10 +25,6 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Install Dependencies
-        run: |
-          pip install -e .
-
       - name: Check Release
         if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ build_dir = "jupytercad/labextension"
 version-cmd = "python scripts/bump-version.py"
 
 [tool.jupyter-releaser.hooks]
-before-build-npm = ["python -m pip install jupyterlab>=4.0.0a32", "jlpm", "jlpm build:prod"]
+before-build-npm = ["python -m pip install jupyterlab --pre -U", "jlpm", "jlpm build:prod"]
 before-build-python = ["jlpm clean:all"]
 
 [tool.check-wheel-contents]


### PR DESCRIPTION
This might help catch potential issues like in https://github.com/QuantStack/jupytercad/blob/3fc5a729af654d676c9db76fc65a28852892ab90/pyproject.toml#L72.

The "Prep Release" and "Publish Release" workflows of the releaser don't install the package in editable mode anymore: https://github.com/jupyter-server/jupyter_releaser/pull/449

Not doing it in the check release workflow should help stay closer to the actual release process.