### PR TITLE
Fix: prevent selecting invisible mesh

### DIFF
--- a/packages/jupytercad-extension/src/mainview.tsx
+++ b/packages/jupytercad-extension/src/mainview.tsx
@@ -338,7 +338,7 @@ export class MainView extends React.Component<IProps, IStates> {
     if (intersects.length > 0) {
       // Find the first intersection with a visible object
       for (const intersect of intersects) {
-        if (!intersect.object.visible) {
+        if (!intersect.object.visible || !intersect.object.parent?.visible) {
           continue;
         }
 


### PR DESCRIPTION
Fix https://github.com/QuantStack/jupytercad/issues/142

Invisible meshes could still be selected through selecting edges