### PR TITLE
NPM Package version fix

### DIFF
--- a/packages/jupytercad-app/package.json
+++ b/packages/jupytercad-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupytercad/jupytercad-app",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0",
   "author": {
     "name": "JupyterCad contributors"
   },

--- a/packages/jupytercad-extension/package.json
+++ b/packages/jupytercad-extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jupytercad/jupytercad-extension",
-    "version": "0.2.0-alpha.0",
+    "version": "0.2.0",
     "description": "A JupyterLab extension for 3D modelling.",
     "keywords": [
         "jupyter",

--- a/packages/jupytercad-opencascade/package.json
+++ b/packages/jupytercad-opencascade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupytercad/jupytercad-opencascade",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0",
   "description": "The custom OpenCascade build for JupyterCAD.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Something went wrong during the 0.2.0 probably due to our `bump_version.py` script. This fixes those versions prior to a manual NPM package release.