### PR TITLE
Missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
-    "jupyter_core",
     "jupyter_server>=2.0.6",
-    "jupyterlab_server",
+    "jupyterlab>=4,<5",
     "jupyter_collaboration>=1.0.0a9,<2",
     "ypywidgets>=0.1.2,<0.2.0",
     "comm>=0.1.2,<0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
+    "jupyter_core",
     "jupyter_server>=2.0.6",
+    "jupyterlab_server",
     "jupyter_collaboration>=1.0.0a9,<2",
     "ypywidgets>=0.1.2,<0.2.0",
     "comm>=0.1.2,<0.2.0",


### PR DESCRIPTION
Fix #183 By bringing back the jupyterlab dependency

We should figure out later why `jupyter cad` needs jupyterlab installed, and why `jupyter_core` and `jupyterlab_server` are not enough for it to work